### PR TITLE
Fix error generated during connection test on questionnaire

### DIFF
--- a/deploy/models/Questionnaire.php
+++ b/deploy/models/Questionnaire.php
@@ -30,7 +30,7 @@ class Questionnaire extends Model
     private function hasNecessaryTables()
     {
         try {
-            $tables = array_map('reset', DB::connection($this->name)->select('SHOW TABLES'));
+            $tables = array_map(function ($table) { return reset($table); }, DB::connection($this->name)->select('SHOW TABLES'));
             if (count(array_intersect($tables, ['cases', 'cspro_jobs', 'level-1'])) === 3) {
                 return ['passes' => true, 'message' => ''];
             } else {

--- a/deploy/routes/web.php
+++ b/deploy/routes/web.php
@@ -44,7 +44,7 @@ Route::middleware(['auth:sanctum', 'verified', 'log_page_views'])->group(functio
         Route::prefix('manage')->name('manage.')->group(function () {
             Route::resource('faq', FaqManagementController::class)->except(['show']);
         });
-        Route::get('connection/{connection}/test', [ConnectionTestController::class, 'test'])->name('connection.test');
+        Route::get('connection/{questionnaire}/test', [ConnectionTestController::class, 'test'])->name('connection.test');
         Route::resource('questionnaire', QuestionnaireController::class);
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,7 @@ Route::middleware(['auth:sanctum', 'verified', 'log_page_views'])->group(functio
         Route::prefix('manage')->name('manage.')->group(function () {
             Route::resource('faq', FaqManagementController::class)->except(['show']);
         });
-        Route::get('connection/{connection}/test', [ConnectionController::class, 'test'])->name('connection.test');
+        Route::get('connection/{questionnaire}/test', [ConnectionController::class, 'test'])->name('connection.test');
         Route::resource('connection', ConnectionController::class);
         Route::get('setting', SettingController::class)->name('setting');
     });


### PR DESCRIPTION
Changed parameter name from {connection} to {questionnaire} so that resource binding can work.

Fixed array_map error 'reset(): Argument https://github.com/tech-acs/chimera-starter-kit/issues/1 ($array) must be passed by reference, value given in' generated by hasNecessaryTables on Questionnaire Model using annonymous function