### PR TITLE
Closes #28 Add indicator templates downloader command

### DIFF
--- a/deploy/commands/DownloadIndicatorTemplates.php
+++ b/deploy/commands/DownloadIndicatorTemplates.php
@@ -7,10 +7,10 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use ZipArchive;
 
-class InstallIndicatorTemplates extends Command
+class DownloadIndicatorTemplates extends Command
 {
-    const LATEST_RELEASE_API = '/releases/latest';
-    const RELEASE_BY_TAG_API = '/releases/tags/';
+    public const LATEST_RELEASE_API = '/releases/latest';
+    public const RELEASE_BY_TAG_API = '/releases/tags/';
     protected ?string $tag = null;
 
     protected string $downloadUrl;
@@ -19,7 +19,7 @@ class InstallIndicatorTemplates extends Command
      *
      * @var string
      */
-    protected $signature = 'chimera:install-indicator-templates
+    protected $signature = 'chimera:download-indicator-templates
                             {--tag= : The version of the indicator templates to install. If not provided, the latest release will be installed.}
                             {--force : Whether to overwrite existing files}';
     /**
@@ -27,7 +27,7 @@ class InstallIndicatorTemplates extends Command
      *
      * @var string
      */
-    protected $description = 'Install indicator templates from the repository to the local storage';
+    protected $description = 'Download indicator templates from the repository to the local storage';
 
     /**
      * Execute the console command.
@@ -36,7 +36,6 @@ class InstallIndicatorTemplates extends Command
      */
     public function handle()
     {
-       
         $downloadPath = $this->downloadIndicatorTemplates();
 
         $this->extractIndicatorTemplates($downloadPath);
@@ -46,22 +45,21 @@ class InstallIndicatorTemplates extends Command
         return Command::SUCCESS;
     }
 
-    protected function getReleaseUrl(): string {
-        $url = config('chimera.indicator_template.url','https://api.github.com/repos/tech-acs/chimera-indicator-templates/');
+    protected function getReleaseUrl(): string
+    {
+        $repository_url = config('chimera.indicator_template.repository_url', 'https://api.github.com/repos/tech-acs/chimera-indicator-templates/');
 
-        if( $this->option('tag')){
-            $url .= self::RELEASE_BY_TAG_API. $this->option('tag');
+        if ($this->option('tag')) {
+            return $repository_url.self::RELEASE_BY_TAG_API. $this->option('tag');
+        } else {
+            return $repository_url.self::LATEST_RELEASE_API;
         }
-        else{
-            $url .= self::LATEST_RELEASE_API;
-        }
-        return $url;
-
     }
 
-   
 
-    protected function getDownloadUrl(): string{
+
+    protected function getDownloadUrl(): string
+    {
         $response = Http::withHeaders([
             'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
         ])->get($this->getReleaseUrl());
@@ -87,7 +85,7 @@ class InstallIndicatorTemplates extends Command
     {
         //Todo: this is a hack, need to find a better way to extract the zip file and remove the root folder
         $destination_path = Storage::disk('indicator_templates')->path('');
-    
+
         $this->info('Extracting indicator templates...');
         //First, extract the zip file
         $zip = new ZipArchive();
@@ -106,5 +104,4 @@ class InstallIndicatorTemplates extends Command
         Storage::disk('indicator_templates')->deleteDirectory($rootFolder);
         $this->info('Extracted indicator templates successfully.');
     }
-    
 }

--- a/deploy/commands/InstallIndicatorTemplates.php
+++ b/deploy/commands/InstallIndicatorTemplates.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use ZipArchive;
+
+class InstallIndicatorTemplates extends Command
+{
+    const LATEST_RELEASE_API = '/releases/latest';
+    const RELEASE_BY_TAG_API = '/releases/tags/';
+    protected ?string $tag = null;
+
+    protected string $downloadUrl;
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'chimera:install-indicator-templates
+                            {--tag= : The version of the indicator templates to install. If not provided, the latest release will be installed.}
+                            {--force : Whether to overwrite existing files}';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install indicator templates from the repository to the local storage';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+       
+        $downloadPath = $this->downloadIndicatorTemplates();
+
+        $this->extractIndicatorTemplates($downloadPath);
+
+        $this->info('Installed indicator templates successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    protected function getReleaseUrl(): string {
+        $url = config('chimera.indicator_template.url','https://api.github.com/repos/tech-acs/chimera-indicator-templates/');
+
+        if( $this->option('tag')){
+            $url .= self::RELEASE_BY_TAG_API. $this->option('tag');
+        }
+        else{
+            $url .= self::LATEST_RELEASE_API;
+        }
+        return $url;
+
+    }
+
+   
+
+    protected function getDownloadUrl(): string{
+        $response = Http::withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
+        ])->get($this->getReleaseUrl());
+        $release = $response->object();
+        $this->downloadUrl = $release->zipball_url;
+        return $this->downloadUrl;
+    }
+
+    protected function downloadIndicatorTemplates(): string
+    {
+        $this->info('Downloading indicator templates...');
+        $downloadUrl = $this->getDownloadUrl();
+        $downloadPath =Storage::disk('indicator_templates')->path('chimera-indicator-templates.zip');
+        Http::sink($downloadPath)->withHeaders([
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36'
+        ])->get($downloadUrl);
+
+        $this->info('Downloaded indicator templates successfully.');
+        return $downloadPath;
+    }
+
+    protected function extractIndicatorTemplates($downloadPath)
+    {
+        //Todo: this is a hack, need to find a better way to extract the zip file and remove the root folder
+        $destination_path = Storage::disk('indicator_templates')->path('');
+    
+        $this->info('Extracting indicator templates...');
+        //First, extract the zip file
+        $zip = new ZipArchive();
+        $zip->open($downloadPath);
+        $zip->extractTo($destination_path);
+        $rootFolder = $zip->getNameIndex(0);
+        $zip->close();
+        //Then, move the files to the root folder
+        $files = Storage::disk('indicator_templates')->allFiles($rootFolder);
+        foreach ($files as $file) {
+            $newFile = str_replace($rootFolder, '', $file);
+            Storage::disk('indicator_templates')->move($file, $newFile);
+            $this->info('Extracted '.$newFile);
+        }
+        //Finally, delete the root folder
+        Storage::disk('indicator_templates')->deleteDirectory($rootFolder);
+        $this->info('Extracted indicator templates successfully.');
+    }
+    
+}

--- a/deploy/resources/stubs/indicators/template.stub
+++ b/deploy/resources/stubs/indicators/template.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use App\Http\Livewire\IndicatorTemplate\{{ parent_class }};
+use App\IndicatorTemplates\{{ parent_class }} as Template;
 
-class {{ class }} extends {{ parent_class }} {
+class {{ class }} extends Template {
 
 }


### PR DESCRIPTION
- add console command to download latest release from git repositories into storage disk indicator_templates.

`php artisan chimera:install-indicator-templates`

- modify makeIndicator to use storage disk for creating new indicators

- change template stub to use parent_class alias for extensions