### PR TITLE
Remove unlink call that breaks data export

### DIFF
--- a/src/Commands/DataExport.php
+++ b/src/Commands/DataExport.php
@@ -52,9 +52,6 @@ class DataExport extends Command
             ->dumpToFile($tmpFile);
 
         try {
-            if (! file_exists($dumpFile)) {
-                unlink($dumpFile);
-            }
             $tmpFileHandle = fopen($tmpFile, 'r');
             $dumpFileHandle = fopen($dumpFile, 'w');
             $databasePasswords = Questionnaire::pluck('password')->all();


### PR DESCRIPTION
The call to unlink is made when the file does not exist which means that if the file does not exist then the unlink call will fail. Rather than fix the if, just removed the whole check since there is no need to unlink the file since it gets overwritten a couple of lines later. fopen() with "w" will truncate the file before writing to it.