### PR TITLE
Typed property $graphDiv initialized to empty string (avoid error 'mu…

### DIFF
--- a/src/Livewire/Chart.php
+++ b/src/Livewire/Chart.php
@@ -25,7 +25,7 @@ abstract class Chart extends Component
     use FilterBasedAxisTitle;
 
     public Indicator $indicator;
-    public string $graphDiv;
+    public string $graphDiv = '';
     public array $data = [];
     public array $layout = [];
     public array $config = [];


### PR DESCRIPTION
…st not be accessed before initialization')