### PR TITLE
fix(summary): handle null start/end dates gracefully

### DIFF
--- a/resources/views/components/summary.blade.php
+++ b/resources/views/components/summary.blade.php
@@ -5,9 +5,11 @@
                 <p class="text-2xl font-semibold text-gray-700">{{ $title }} @if (! is_null($area)) ({{ $area->name }}) @endif</p>
             </dt>
             <dd class="flex items-baseline">
+                @if ($dates['start'] && $dates['end'])
                 <p class="flex items-baseline text-sm font-semibold">
                     {{$dates['start']->locale(app()->getLocale())->isoFormat('ll')}} - {{$dates['end']->locale(app()->getLocale())->isoFormat('ll')}}
                 </p>
+                @endif
             </dd>
         </div>
         <div class="flex flex-col">

--- a/src/Components/Summary.php
+++ b/src/Components/Summary.php
@@ -36,8 +36,11 @@ class Summary extends Component
         }
     }
 
-    private function makeProgressStatement(Carbon $s, Carbon $e, Carbon $now)
+    private function makeProgressStatement(?Carbon $s, ?Carbon $e, Carbon $now)
     {
+        if (is_null($s) || is_null($e)) {
+            return '-';
+        }
         if ($now->isBefore($s)) {
             $progress = __(':diff days to go', ['diff' => (int) $now->diffInDays($s, absolute: true)]);
         } elseif ($now->isBetween($s, $e)) {


### PR DESCRIPTION
Data sources without start_date and end_date fields caused a TypeError in makeProgressStatement(). Allow nullable Carbon parameters and return '-' when dates are absent. Guard the date range display in the view.