### PR TITLE
fix(query-builder): throw proper exception when query fragments missing

### DIFF
--- a/src/Services/BreakoutQueryBuilder.php
+++ b/src/Services/BreakoutQueryBuilder.php
@@ -56,7 +56,11 @@ class BreakoutQueryBuilder
         string $partialCaseIdentifyingCondition = 'cases.partial_save_mode is NULL'
     ) {
         $this->filterPath = $filterPath;
-        [$selectColumns, $whereConditions, $concernedTables] = QueryFragmentFactory::make($dataSource)->getSqlFragments($filterPath);
+        $fragment = QueryFragmentFactory::make($dataSource);
+        if (is_null($fragment)) {
+            throw new \Exception("Query fragments not defined for data source '{$dataSource}'.");
+        }
+        [$selectColumns, $whereConditions, $concernedTables] = $fragment->getSqlFragments($filterPath);
 
         try {
             $this->dbConnection = DB::connection($dataSource);


### PR DESCRIPTION
QueryFragmentFactory::make() returns null when no QueryFragments class exists for the data source. The constructor called ->getSqlFragments() on null, causing an uncatchable TypeError. Now throws a catchable \Exception so existing try/catch blocks in callers handle it gracefully.