### PR TITLE
build(deps): replace plotly.js-dist with plotly.js-cartesian-dist

### DIFF
--- a/deploy/resources/js/PlotlyChart.js
+++ b/deploy/resources/js/PlotlyChart.js
@@ -1,4 +1,4 @@
-import Plotly from 'plotly.js-dist';
+import Plotly from 'plotly.js-cartesian-dist';
 import fr from 'plotly.js-locales/fr';
 import ptPT from 'plotly.js-locales/pt-pt';
 

--- a/deploy/resources/js/app.js
+++ b/deploy/resources/js/app.js
@@ -1,6 +1,6 @@
 import './bootstrap';
 
-import Plotly from 'plotly.js-dist';
+import Plotly from 'plotly.js-cartesian-dist';
 window.Plotly = Plotly;
 
 import PlotlyChart from "./PlotlyChart.js";

--- a/resources/views/developer/indicator-editor/index.blade.php
+++ b/resources/views/developer/indicator-editor/index.blade.php
@@ -93,7 +93,7 @@
             :data="$data"
             :layout="$layout"
             :config="$config"
-            :trace-types="['bar', 'scatter', 'pie', 'histogram', 'line', 'area', 'box', 'sunburst']"
+            :trace-types="['bar', 'scatter', 'pie', 'histogram', 'line', 'area', 'box']"
             sync-mode="manual"
             :preload-schema="true"
             :show-export="true"

--- a/src/Traits/PackageTasksTrait.php
+++ b/src/Traits/PackageTasksTrait.php
@@ -11,7 +11,7 @@ trait PackageTasksTrait
 {
     public array $requiredNodePackages = [
         'leaflet' => '^1.9',
-        'plotly.js-dist' => '^3.5',
+        'plotly.js-cartesian-dist' => '^3.5',
         'plotly.js-locales' => '^3.5',
         'alpinejs' => '^3.14',
         '@tailwindcss/aspect-ratio' => '^0.4.2',


### PR DESCRIPTION
Swap full plotly bundle (~4.6 MB) for the cartesian partial bundle (~1.4 MB). Removes sunburst from editor trace types since cartesian does not include it.